### PR TITLE
Fix null bbox value

### DIFF
--- a/packages/rise/rise/lib/location.py
+++ b/packages/rise/rise/lib/location.py
@@ -294,15 +294,18 @@ class LocationResponse(BaseModel):
         if sortby:
             sort_by_properties_in_place(geojson_features, sortby)
 
-        validated_geojson = FeatureCollection(
-            type="FeatureCollection", features=geojson_features
-        )
         if itemsIDSingleFeature:
-            return GeojsonFeatureDict(**geojson_features[0].model_dump(by_alias=True))
+            return GeojsonFeatureDict(
+                **geojson_features[0].model_dump(by_alias=True, exclude_unset=True)
+            )
+        else:
+            validated_geojson = FeatureCollection(
+                type="FeatureCollection", features=geojson_features
+            )
 
-        return GeojsonFeatureCollectionDict(
-            **validated_geojson.model_dump(by_alias=True)
-        )
+            return GeojsonFeatureCollectionDict(
+                **validated_geojson.model_dump(by_alias=True, exclude_unset=True)
+            )
 
 
 class LocationResponseWithIncluded(LocationResponse):

--- a/packages/snotel/snotel/lib/locations.py
+++ b/packages/snotel/snotel/lib/locations.py
@@ -191,11 +191,14 @@ class LocationCollection:
             assert len(features) == 1, (
                 "The user queried a single item but we have more than one present. This is a sign that filtering by locationid wasn't done properly"
             )
-            return GeojsonFeatureDict(**features[0].model_dump())
+            return GeojsonFeatureDict(**features[0].model_dump(exclude_unset=True))
         return GeojsonFeatureCollectionDict(
             **{
                 "type": "FeatureCollection",
-                "features": [feature.model_dump(by_alias=True) for feature in features],
+                "features": [
+                    feature.model_dump(by_alias=True, exclude_unset=True)
+                    for feature in features
+                ],
             }
         )
 


### PR DESCRIPTION
fixes extra bbox key appearing; this is since geojson pydantic adds it implicitly and thus you need to exclude unset to make it so pydantic doesnt include it when deserializing